### PR TITLE
Catalan translation: small correction

### DIFF
--- a/openfortigui/lang/openfortigui_ca.ts
+++ b/openfortigui/lang/openfortigui_ca.ts
@@ -267,7 +267,7 @@
     <message>
         <location filename="../mainwindow.cpp" line="679"/>
         <source>VPN %1 is disconnected</source>
-        <translation>VPN %1 ist getrennt</translation>
+        <translation>VPN %1 s'ha desconnectat</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="750"/>


### PR DESCRIPTION
Just fixing an untranslated string, but one seen on every connection, "VPN is disconnected" comes out in German if using Catalan!