### PR TITLE
Fixes bug where realm was being passed to the user_key argument

### DIFF
--- a/openfortigui/proc/vpnworker.cpp
+++ b/openfortigui/proc/vpnworker.cpp
@@ -345,7 +345,7 @@ void vpnWorker::process()
         add_trusted_cert(&config, vpnConfig.trusted_cert.toStdString().c_str());
 
     if(!vpnConfig.realm.isEmpty())
-        strncpy(config.realm, vpnConfig.user_key.toStdString().c_str(), FIELD_SIZE);
+        strncpy(config.realm, vpnConfig.realm.toStdString().c_str(), FIELD_SIZE);
 
     config.set_dns = (vpnConfig.set_dns) ? 1 : 0;
     config.verify_cert = (vpnConfig.verify_cert) ? 1 : 0;


### PR DESCRIPTION
I was setting this up for work and found that the realm option was not working. Looking through the code, I found that user_key was being passed where realm should be. I built and tested this and it does work with vpn realms.