### PR TITLE
Add support for MacOS build

### DIFF
--- a/openfortigui/openfortigui.pro
+++ b/openfortigui/openfortigui.pro
@@ -84,4 +84,7 @@ FORMS    += mainwindow.ui \
 RESOURCES += \
     res.qrc
 
-unix:!macx:!symbian: LIBS += -lcrypto -lpthread -lssl -lutil -lqt5keychain
+QMAKE_CFLAGS += $$(CPPFLAGS)
+QMAKE_LFLAGS += $$(LDFLAGS)
+
+unix:!symbian: LIBS += -lcrypto -lpthread -lssl -lutil -lqt5keychain

--- a/openfortigui/vpnhelper.cpp
+++ b/openfortigui/vpnhelper.cpp
@@ -48,7 +48,7 @@ vpnHelperResult vpnHelper::checkSystemPasswordStoreAvailable()
     vpnHelperResult result;
     result.status = false;
 
-    QKeychain::WritePasswordJob job(QLatin1String(openfortigui_config::password_manager_namespace));
+    QKeychain::WritePasswordJob job ((QLatin1String(openfortigui_config::password_manager_namespace)));
     job.setAutoDelete(false);
     job.setKey("testkeystore");
     job.setBinaryData("test");
@@ -63,7 +63,7 @@ vpnHelperResult vpnHelper::checkSystemPasswordStoreAvailable()
         return result;
     }
 
-    QKeychain::DeletePasswordJob job2(QLatin1String(openfortigui_config::password_manager_namespace));
+    QKeychain::DeletePasswordJob job2 ((QLatin1String(openfortigui_config::password_manager_namespace)));
     job2.setAutoDelete(false);
     job2.setKey("testkeystore");
     QEventLoop loop2;
@@ -86,7 +86,7 @@ vpnHelperResult vpnHelper::systemPasswordStoreWrite(const QString &key, const QS
     vpnHelperResult result;
     result.status = false;
 
-    QKeychain::WritePasswordJob job(QLatin1String(openfortigui_config::password_manager_namespace));
+    QKeychain::WritePasswordJob job ((QLatin1String(openfortigui_config::password_manager_namespace)));
     job.setAutoDelete(false);
     job.setKey(key);
     job.setBinaryData(data.toUtf8());
@@ -111,7 +111,7 @@ vpnHelperResult vpnHelper::systemPasswordStoreRead(const QString &key)
     result.status = false;
     result.data = "";
 
-    QKeychain::ReadPasswordJob job(QLatin1String(openfortigui_config::password_manager_namespace));
+    QKeychain::ReadPasswordJob job ((QLatin1String(openfortigui_config::password_manager_namespace)));
     job.setAutoDelete(false);
     job.setKey(key);
     QEventLoop loop;
@@ -137,7 +137,7 @@ vpnHelperResult vpnHelper::systemPasswordStoreDelete(const QString &key)
     vpnHelperResult result;
     result.status = false;
 
-    QKeychain::DeletePasswordJob job(QLatin1String(openfortigui_config::password_manager_namespace));
+    QKeychain::DeletePasswordJob job ((QLatin1String(openfortigui_config::password_manager_namespace)));
     job.setAutoDelete(false);
     job.setKey(key);
     QEventLoop loop;


### PR DESCRIPTION
Fix https://github.com/theinvisible/openfortigui/issues/56
- Remove `!macx` from `.pro` file
- Add `QMAKE_CFLAGS` and `QMAKE_LFLAGS` to `.pro` file
- Fix `parameter declarator cannot be qualified` error while run `make -j4` on macOS