### PR TITLE
Add shortcuts for Hide and Exit

### DIFF
--- a/openfortigui/mainwindow.ui
+++ b/openfortigui/mainwindow.ui
@@ -92,7 +92,7 @@
      <x>0</x>
      <y>0</y>
      <width>900</width>
-     <height>23</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuDatei">
@@ -148,6 +148,9 @@
    <property name="text">
     <string>Exit</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+Q</string>
+   </property>
   </action>
   <action name="actionMenuAbout">
    <property name="icon">
@@ -183,6 +186,9 @@
    </property>
    <property name="text">
     <string>Hide</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+W</string>
    </property>
   </action>
   <action name="actionMenuSettings">


### PR DESCRIPTION
Add Ctrl-W to hide the main window, and add Ctrl-Q to quit the
program.  These are standard UI shortcuts for closing a window and
quitting a program, respectively.

I use openfortigui on an almost daily basis, and often, when I'm shutting my laptop down for the day, I find myself using Ctrl-Q to close most of the other programs that I use.  I find it mildly annoying to have to go to the task icon or click the File menu when I want to quit openfortigui, particularly when I'm on a roll using Ctrl-Q.  I therefore made this little change to mainwindow.ui for my convenience and thought that I would share.