### PR TITLE
Fix issue 64: segfault on Debian 10(testing)

### DIFF
--- a/openfortigui/vpnmanager.cpp
+++ b/openfortigui/vpnmanager.cpp
@@ -74,6 +74,7 @@ void vpnManager::startVPN(const QString &name)
         return;
 
     QStringList arguments;
+    arguments << "-E";
     arguments << QCoreApplication::applicationFilePath();
     arguments << "--start-vpn";
     arguments << "--vpn-name";


### PR DESCRIPTION
Add "-E" to sudo/vpn arguments to work around new policy defaults of
sudo on Debian and Ubuntu.