### PR TITLE
Add option to always ask OTP with a profile

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,107 @@
+cmake_minimum_required (VERSION 3.9)
+project (openfortigui)
+
+set (CMAKE_CONFIGURATION_TYPES Debug Release)
+
+# Set the CXX standard as C++11
+set(CMAKE_CXX_STANDARD 11)
+
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC ON)
+
+find_package(Qt5 REQUIRED Core Widgets Network)
+
+# Add 'd' suffix to debug libs
+set(CMAKE_DEBUG_POSTFIX _debug)
+
+# Generate debug symbol file (pdb)
+if (${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /DEBUG")
+endif ()
+
+# Set lib flag
+# add_definitions(-DFORTI_LIBRARY)
+add_definitions(-DHAVE_USR_SBIN_PPPD=1
+    -DHAVE_PROC_NET_ROUTE=1
+    -DHAVE_STRUCT_TERMIOS=1
+    -DHAVE_RT_ENTRY_WITH_RT_DST=1
+    -DHAVE_SYSTEMD=0
+    -DHAVE_X509_CHECK_HOST=1
+    -DPPP_PATH="/usr/sbin/pppd"
+    -DRESOLVCONF_PATH=""
+    -DHAVE_PTY_H=1)
+
+#########################################################
+# Sources
+#########################################################
+
+# Add the qt include dirs
+include_directories(${QT_INCLUDE_DIRS})
+
+include_directories(openfortigui openfortigui/openfortivpn)
+
+list (APPEND FORTI_LIBS
+    Qt5::Widgets
+    Qt5::Network
+    Qt5::Core
+    crypto
+    ssl
+    pthread
+    util
+    qt5keychain
+)
+
+list (APPEND FORTI_SOURCE_FILES
+openfortigui/main.cpp
+openfortigui/mainwindow.cpp
+openfortigui/openfortivpn/src/config.c
+openfortigui/openfortivpn/src/hdlc.c
+openfortigui/openfortivpn_local/src/http.c
+openfortigui/openfortivpn/src/io.c
+openfortigui/openfortivpn/src/ipv4.c
+openfortigui/openfortivpn/src/log.c
+openfortigui/openfortivpn/src/tunnel.c
+openfortigui/openfortivpn/src/userinput.c
+openfortigui/openfortivpn/src/xml.c
+openfortigui/vpnmanager.cpp
+openfortigui/ticonfmain.cpp
+openfortigui/vpnapi.cpp
+openfortigui/proc/vpnprocess.cpp
+openfortigui/vpnprofile.cpp
+openfortigui/vpnprofileeditor.cpp
+openfortigui/proc/vpnworker.cpp
+openfortigui/vpngroup.cpp
+openfortigui/vpngroupeditor.cpp
+openfortigui/vpnsetting.cpp
+openfortigui/vpnlogin.cpp
+openfortigui/vpnhelper.cpp
+openfortigui/vpnlogger.cpp
+openfortigui/vpnotplogin.cpp
+openfortigui/setupwizard.cpp
+openfortigui/vpnchangelog.cpp
+)
+
+# Add resource file if needed
+list (APPEND FORTI_SOURCE_FILES openfortigui/res.qrc)
+
+
+#Add UI Files if needed
+list (APPEND FORTI_SOURCE_FILES
+    openfortigui/mainwindow.ui
+    openfortigui/vpnprofileeditor.ui
+    openfortigui/vpngroupeditor.ui
+    openfortigui/vpnsetting.ui
+    openfortigui/vpnlogin.ui
+    openfortigui/vpnotplogin.ui
+    openfortigui/setupwizard.ui
+    openfortigui/vpnchangelog.ui
+)
+
+# Find includes in corresponding build directories
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+
+
+add_executable(${PROJECT_NAME} ${FORTI_SOURCE_FILES})
+
+target_link_libraries (${PROJECT_NAME} ${FORTI_LIBS} ${EXTRA_LIBRARIES})

--- a/openfortigui/ticonfmain.cpp
+++ b/openfortigui/ticonfmain.cpp
@@ -227,6 +227,7 @@ void tiConfVpnProfiles::saveVpnProfile(const vpnProfile &profile)
     f->setValue("debug", profile.debug);
     f->setValue("realm", profile.realm);
     f->setValue("autostart", profile.autostart);
+    f->setValue("alwaysAskOtp", profile.alwaysAskOtp);
     f->setValue("half_internet_routers", profile.half_internet_routers);
     f->setValue("pppd_log_file", profile.pppd_log_file);
     f->setValue("pppd_plugin_file", profile.pppd_plugin_file);
@@ -316,6 +317,7 @@ void tiConfVpnProfiles::readVpnProfiles()
                 vpnprofile->debug = f->value("debug").toBool();
                 vpnprofile->realm = f->value("realm").toString();
                 vpnprofile->autostart = f->value("autostart").toBool();
+                vpnprofile->alwaysAskOtp = f->value("alwaysAskOtp").toBool();
                 vpnprofile->half_internet_routers = f->value("half_internet_routers").toBool();
                 vpnprofile->pppd_log_file = f->value("pppd_log_file").toString();
                 vpnprofile->pppd_plugin_file = f->value("pppd_plugin_file").toString();

--- a/openfortigui/vpnmanager.cpp
+++ b/openfortigui/vpnmanager.cpp
@@ -27,6 +27,7 @@
 #include <QJsonObject>
 #include <QJsonArray>
 #include <QMessageBox>
+#include <QInputDialog>
 
 vpnManager::vpnManager(QObject *parent) : QObject(parent)
 {
@@ -357,12 +358,23 @@ void vpnClientConnection::submitPassStoreCred()
     QJsonDocument json;
     QJsonObject jsTop;
     vpnApi data;
+    QString password;
     data.action = vpnApi::ACTION_STOREPASS_SUBMIT;
     data.objName = name;
 
     tiConfVpnProfiles profiles;
     vpnProfile *profile = profiles.getVpnProfileByName(name);
-    jsTop["password"] = profile->readPassword();
+    password = profile->readPassword();
+
+    // Ask for otp if needed
+    if (profile->alwaysAskOtp)
+    {
+        QString otp = QInputDialog::getText(nullptr, "Enter OTP","OTP");
+        if (!otp.isEmpty())
+            password = QString("%1,%2").arg(password).arg(otp);
+    }
+
+    jsTop["password"] = password;
 
     json.setObject(jsTop);
     data.data = json.toJson();

--- a/openfortigui/vpnprofile.cpp
+++ b/openfortigui/vpnprofile.cpp
@@ -44,6 +44,7 @@ vpnProfile::vpnProfile()
     verify_cert = false;
     insecure_ssl = false;
     autostart = false;
+    alwaysAskOtp = false;
 
     pppd_no_peerdns = false;
     pppd_log_file = "";

--- a/openfortigui/vpnprofile.h
+++ b/openfortigui/vpnprofile.h
@@ -55,6 +55,7 @@ public:
     bool insecure_ssl;
     bool debug;
     bool autostart;
+    bool alwaysAskOtp;
 
     bool pppd_no_peerdns;
     QString pppd_log_file;

--- a/openfortigui/vpnprofileeditor.cpp
+++ b/openfortigui/vpnprofileeditor.cpp
@@ -74,6 +74,7 @@ void vpnProfileEditor::loadVpnProfile(const QString &profile, vpnProfile::Origin
     ui->cbDebug->setChecked(config->debug);
     ui->leRealm->setText(config->realm);
     ui->cbAutostart->setChecked(config->autostart);
+    ui->cbAlwaysAskOtp->setChecked(config->alwaysAskOtp);
     ui->cbHalfInternetRoutes->setChecked(config->half_internet_routers);
 
     ui->cbPPPDNoPeerDNS->setChecked(config->pppd_no_peerdns);
@@ -209,6 +210,7 @@ void vpnProfileEditor::on_btnSave_clicked()
     vpn.debug = ui->cbDebug->isChecked();
     vpn.realm = ui->leRealm->text();
     vpn.autostart = ui->cbAutostart->isChecked();
+    vpn.alwaysAskOtp = ui->cbAlwaysAskOtp->isChecked();
     vpn.half_internet_routers = ui->cbHalfInternetRoutes->isChecked();
 
     vpn.pppd_log_file = ui->lePPPDLogFile->text();

--- a/openfortigui/vpnprofileeditor.ui
+++ b/openfortigui/vpnprofileeditor.ui
@@ -397,6 +397,20 @@
             </property>
            </widget>
           </item>
+          <item row="8" column="0">
+           <widget class="QLabel" name="label_23">
+            <property name="text">
+             <string>Always ask for OTP</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1">
+           <widget class="QCheckBox" name="cbAlwaysAskOtp">
+            <property name="text">
+             <string/>
+            </property>
+           </widget>
+          </item>
          </layout>
         </widget>
        </item>


### PR DESCRIPTION
I had issues with my company VPN, where the OTP dialog never pops up. I added an option to always show the OTP dialog. This will send the final passwords as `<password>,<otp>` format as needed by the FortiVPN