### PR TITLE
Adds package Keychain from Qt5 to find_package of CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_AUTOMOC ON)
 set(CMAKE_AUTORCC ON)
 set(CMAKE_AUTOUIC ON)
 
-find_package(Qt5 REQUIRED Core Widgets Network)
+find_package(Qt5 REQUIRED Core Widgets Network Keychain)
 
 # Add 'd' suffix to debug libs
 set(CMAKE_DEBUG_POSTFIX _debug)


### PR DESCRIPTION
Trying to compile openfortigui in Linux without any QT5 packages i have got an error in source `vpnhelper.cpp ` caused by an absence of package `qt5keychain-dev`. Later I looked at the CMakeLists.txt file and found that the directive `find_package` was missing the Keychain check. Added it to `find_package` and then the compilation could go on. Please, merge this pull request. 