### PR TITLE
Set default to password if username pre-populated

### DIFF
--- a/openfortigui/vpnlogin.cpp
+++ b/openfortigui/vpnlogin.cpp
@@ -43,6 +43,10 @@ void vpnLogin::setData(vpnManager *manager, const QString &name)
     tiConfVpnProfiles vpnss;
     vpnProfile *profile = vpnss.getVpnProfileByName(vpnname);
     ui->leUsername->setText(profile->username);
+    if(profile->username.length() > 0)
+    {
+            ui->lePassword->setFocus();
+    }
 }
 
 void vpnLogin::initAfter()


### PR DESCRIPTION
Being a daily user of this program myself, I recommend the focus be set to the password field if the username field is already populated.