### PR TITLE
Disable config menu items when the config file is not writable

### DIFF
--- a/openfortigui/ticonfmain.cpp
+++ b/openfortigui/ticonfmain.cpp
@@ -181,6 +181,11 @@ QString tiConfMain::readGwCertCache(const QString &vpnname)
     return hash;
 }
 
+bool tiConfMain::isWritable()
+{
+    return settings->isWritable();
+}
+
 QString tiConfMain::formatPath(const QString &path)
 {
     QString p = path;

--- a/openfortigui/ticonfmain.h
+++ b/openfortigui/ticonfmain.h
@@ -41,6 +41,8 @@ public:
     void saveGwCertCache(const QString &vpnname, const QString &certhash);
     QString readGwCertCache(const QString &vpnname);
 
+    bool isWritable();
+
     static QString formatPath(const QString &path);
     static QString formatPathReverse(const QString &path);
     static QString setMainConfig(const QString &config);

--- a/openfortigui/vpnsetting.cpp
+++ b/openfortigui/vpnsetting.cpp
@@ -52,6 +52,27 @@ vpnSetting::vpnSetting(QWidget *parent) :
     ui->leLogs->setText(confMain.getValue("paths/logs").toString());
     ui->cbDisableNotifications->setChecked(confMain.getValue("gui/disable_notifications").toBool());
     ui->cbConnectonDblClick->setChecked(confMain.getValue("gui/connect_on_dblclick").toBool());
+
+    if(!confMain.isWritable()) // Disable everything when the config file is not writable
+    {
+        ui->cbStartMinimized->setDisabled(true);
+        ui->cbDebug->setDisabled(true);
+        ui->cbUseSystemPasswordStore->setDisabled(true);
+        ui->cbSUDOPreserveEnv->setDisabled(true);
+        ui->leAESKey->setDisabled(true);
+        ui->leAESIV->setDisabled(true);
+        ui->leLocalVPNProfiles->setDisabled(true);
+        ui->leLocalVPNGroups->setDisabled(true);
+        ui->leGlobalVPNProfiles->setDisabled(true);
+        ui->leLogs->setDisabled(true);
+        ui->btnChooseLocalVPNProfiles->setDisabled(true);
+        ui->btnChooseLocalVPNGroups->setDisabled(true);
+        ui->btnChooseGlobalVPNProfiles->setDisabled(true);
+        ui->btnChooseLogs->setDisabled(true);
+        ui->cbDisableNotifications->setDisabled(true);
+        ui->cbConnectonDblClick->setDisabled(true);
+        ui->cbDisallowUnsecureCertificates->setDisabled(true);
+    }
 }
 
 vpnSetting::~vpnSetting()


### PR DESCRIPTION
This is done to allow a rudimentary way for sysadmins to lock the config of their users