### PR TITLE
Add config option to disallow usage of custom certs

### DIFF
--- a/openfortigui/mainwindow.cpp
+++ b/openfortigui/mainwindow.cpp
@@ -801,6 +801,15 @@ void MainWindow::onClientCertValidationFAiled(QString vpnname, QString buffer)
         return;
 
     info.prepend(tr("Gateway certificate validation failed and the certificate digest is not in the local whitelist nor a valid CA is provided. Certificate details:\n\n"));
+
+    tiConfMain main_settings;
+    bool disallowUnsecureCertificates = main_settings.getValue("main/disallow_unsecure_certificates").toBool();
+    if(disallowUnsecureCertificates)
+    {
+        QMessageBox::critical(this, tr("Gateway certificate validation failed"), info);
+        return;
+    }
+
     info.append(tr("\n\nAdd certificate to VPN-profile whitelist?"));
 
     tiConfVpnProfiles profiles;

--- a/openfortigui/vpnprofileeditor.cpp
+++ b/openfortigui/vpnprofileeditor.cpp
@@ -128,6 +128,15 @@ void vpnProfileEditor::loadVpnProfile(const QString &profile, vpnProfile::Origin
         ui->comboMinTLSVersion->setDisabled(true);
         ui->cbTrustAllGwCerts->setDisabled(true);
     }
+
+    tiConfMain main_settings;
+    bool disallowUnsecureCertificates = main_settings.getValue("main/disallow_unsecure_certificates").toBool();
+    if(disallowUnsecureCertificates)
+    {
+        ui->gbCertificate->setDisabled(true);
+        ui->cbTrustAllGwCerts->setDisabled(true);
+        ui->leTrustedCert->setDisabled(true);
+    }
 }
 
 void vpnProfileEditor::on_btnChooseUserCert_clicked()

--- a/openfortigui/vpnsetting.cpp
+++ b/openfortigui/vpnsetting.cpp
@@ -45,6 +45,7 @@ vpnSetting::vpnSetting(QWidget *parent) :
         ui->leAESKey->setText(confMain.getValue("main/aeskey").toString());
         ui->leAESIV->setText(confMain.getValue("main/aesiv").toString());
     }
+    ui->cbDisallowUnsecureCertificates->setChecked(confMain.getValue("main/disallow_unsecure_certificates").toBool());	
 
     ui->leLocalVPNProfiles->setText(confMain.getValue("paths/localvpnprofiles").toString());
     ui->leLocalVPNGroups->setText(confMain.getValue("paths/localvpngroups").toString());
@@ -84,6 +85,8 @@ void vpnSetting::on_btnSave_clicked()
 
     confMain.setValue("main/aeskey", ui->leAESKey->text());
     confMain.setValue("main/aesiv", ui->leAESIV->text());
+
+    confMain.setValue("main/disallow_unsecure_certificates", ui->cbDisallowUnsecureCertificates->isChecked());
 
     confMain.setValue("paths/localvpnprofiles", tiConfMain::formatPathReverse(ui->leLocalVPNProfiles->text()));
     confMain.setValue("paths/localvpngroups", tiConfMain::formatPathReverse(ui->leLocalVPNGroups->text()));

--- a/openfortigui/vpnsetting.ui
+++ b/openfortigui/vpnsetting.ui
@@ -114,6 +114,20 @@
           </property>
          </widget>
         </item>
+        <item row="5" column="0">
+         <widget class="QLabel" name="label_13">
+          <property name="text">
+           <string>Disallow unsecure certificates</string>
+          </property>
+         </widget>
+        </item>
+        <item row="5" column="1">
+         <widget class="QCheckBox" name="cbDisallowUnsecureCertificates">
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
        </layout>
       </item>
      </layout>


### PR DESCRIPTION
This is done to disallow users form accepting or configuring unsecure certs