### PR TITLE
Fix segfault caused by cross-thread QProcess read in vpnLogger

### DIFF
--- a/openfortigui/proc/vpnprocess.cpp
+++ b/openfortigui/proc/vpnprocess.cpp
@@ -32,8 +32,10 @@
 vpnProcess::vpnProcess(QObject *parent) : QObject(parent)
 {
     init_last_tunnel = false;
-    thread_worker = 0;
-    thread_vpn = 0;
+    thread_worker = nullptr;
+    thread_vpn = nullptr;
+    observer = nullptr;
+    observerStats = nullptr;
 }
 
 void vpnProcess::setup(const QString &vpnname)
@@ -70,7 +72,12 @@ void vpnProcess::closeProcess()
 {
     qDebug() << "shutting down vpn process::" << name;
 
-    if(thread_worker != 0 && thread_vpn != 0)
+    if(observer != nullptr)
+        observer->stop();
+    if(observerStats != nullptr)
+        observerStats->stop();
+
+    if(thread_worker != nullptr && thread_vpn != nullptr)
     {
         thread_worker->end();
         thread_vpn->quit();
@@ -226,7 +233,7 @@ void vpnProcess::sendCMD(const vpnApi &cmd)
 
 void vpnProcess::updateStats()
 {
-    if(thread_worker->ptr_tunnel != 0)
+    if(thread_worker != nullptr && thread_worker->ptr_tunnel != nullptr)
     {
         QFile file("/proc/net/dev");
         if(!file.open(QIODevice::ReadOnly | QIODevice::Text))
@@ -381,7 +388,7 @@ void vpnProcess::onVPNStatusChanged(vpnClientConnection::connectionStatus status
 
 void vpnProcess::onObserverUpdate()
 {
-    if(thread_worker->ptr_tunnel != 0)
+    if(thread_worker != nullptr && thread_worker->ptr_tunnel != nullptr)
     {
         if(!init_last_tunnel)
         {
@@ -419,7 +426,8 @@ void vpnProcess::onObserverUpdate()
 
 void vpnProcess::onStatsUpdate()
 {
-    if(thread_worker->ptr_tunnel->state == STATE_UP)
+    if(thread_worker != nullptr && thread_worker->ptr_tunnel != nullptr
+       && thread_worker->ptr_tunnel->state == STATE_UP)
     {
         updateStats();
         submitStats();

--- a/openfortigui/vpnlogger.cpp
+++ b/openfortigui/vpnlogger.cpp
@@ -20,21 +20,19 @@
 #include <QDebug>
 #include <QDateTime>
 #include <QThread>
+#include <QMetaObject>
 
 #include "ticonfmain.h"
 
 vpnLogger::vpnLogger(QObject *parent) : QObject(parent)
 {
-    logMapperStdout = new QSignalMapper(this);
     logMapperFinished = new QSignalMapper(this);
-    loggers = QMap<QString, QProcess*>();
+    loggers = QMap<QString, QPointer<QProcess>>();
     logfiles = QMap<QString, QFile*>();
-    loglocker = QMap<QString, bool>();
     logCertFailedMode = QMap<QString, bool>();
     logCertFailedBuffer = QMap<QString, QString>();
     vpnConfigs = QMap<QString, vpnProfile>();
 
-    connect(logMapperStdout, SIGNAL(mapped(QString)), this, SLOT(logVPNOutput(QString)));
     connect(logMapperFinished, SIGNAL(mapped(QString)), this, SLOT(procFinished(QString)));
 }
 
@@ -51,7 +49,6 @@ void vpnLogger::addVPN(const QString &name, QProcess *proc)
 
     vpnConfigs.insert(name, *profile);
     loggers.insert(name, proc);
-    loglocker.insert(name, false);
     logCertFailedMode.insert(name, false);
     logCertFailedBuffer.insert(name, "");
     if(!logfiles.contains(name))
@@ -61,33 +58,25 @@ void vpnLogger::addVPN(const QString &name, QProcess *proc)
         logfiles.insert(name, file);
     }
 
-    connect(proc, SIGNAL(readyReadStandardOutput()), logMapperStdout, SLOT(map()));
+    connect(proc, &QProcess::readyReadStandardOutput, proc, [this, name, proc]() {
+        QByteArray data = proc->readAll();
+        if(!data.isEmpty())
+            QMetaObject::invokeMethod(this, "logVPNData", Qt::QueuedConnection,
+                                      Q_ARG(QString, name), Q_ARG(QByteArray, data));
+    });
     connect(proc, SIGNAL(finished(int)), logMapperFinished, SLOT(map()));
-    logMapperStdout->setMapping(proc, name);
     logMapperFinished->setMapping(proc, name);
 }
 
-void vpnLogger::logVPNOutput(const QString &name)
+void vpnLogger::logVPNData(const QString &name, const QByteArray &data)
 {
-    QThread::msleep(200);
-
-    QProcess *proc = loggers[name];
-
-    if(proc == 0)
+    QFile *logfile = logfiles.value(name, nullptr);
+    if(logfile == nullptr)
         return;
 
-    if(proc->bytesAvailable() == 0 && proc->isReadable())
-        return;
-
-    qDebug() << QDateTime::currentMSecsSinceEpoch() << "bytes avail::" << proc->bytesAvailable();
-
-    QByteArray blog;
-    blog.append(proc->read(proc->bytesAvailable()));
-
-    QFile *logfile = logfiles[name];
     QTextStream out(logfile);
+    QString toLog = QString::fromUtf8(data);
 
-    QString toLog = QString::fromUtf8(blog);
     if(toLog.contains("Please load the ppp"))
     {
         vpnMsg msg;
@@ -126,20 +115,21 @@ void vpnLogger::logVPNOutput(const QString &name)
         return;
     }
 
+    bool needsOtp = false;
     if(vpnConfigs[name].otp_prompt.isEmpty())
     {
-        if(toLog.contains("Please") ||
-           toLog.contains("2factor authentication token:") ||
-           toLog.contains("Two-factor authentication") ||
-           toLog.contains("one-time password"))
-        {
-            emit OTPRequest(proc);
-        }
+        needsOtp = toLog.contains("Please") ||
+                   toLog.contains("2factor authentication token:") ||
+                   toLog.contains("Two-factor authentication") ||
+                   toLog.contains("one-time password");
     } else {
-        if(toLog.contains(vpnConfigs[name].otp_prompt))
-        {
+        needsOtp = toLog.contains(vpnConfigs[name].otp_prompt);
+    }
+    if(needsOtp)
+    {
+        QPointer<QProcess> proc = loggers.value(name);
+        if(!proc.isNull())
             emit OTPRequest(proc);
-        }
     }
 
     if(toLog.contains("Gateway certificate validation failed, and the certificate digest is not in the local whitelist."))
@@ -162,7 +152,17 @@ void vpnLogger::logVPNOutput(const QString &name)
 
 void vpnLogger::procFinished(const QString &name)
 {
-    loggers[name] = 0;
+    loggers.remove(name);
+    logCertFailedMode.remove(name);
+    logCertFailedBuffer.remove(name);
+    vpnConfigs.remove(name);
+    QFile *logfile = logfiles.value(name, nullptr);
+    if(logfile != nullptr)
+    {
+        logfile->close();
+        delete logfile;
+    }
+    logfiles.remove(name);
 }
 
 void vpnLogger::process()

--- a/openfortigui/vpnlogger.h
+++ b/openfortigui/vpnlogger.h
@@ -21,6 +21,7 @@
 #include <QObject>
 #include <QSignalMapper>
 #include <QProcess>
+#include <QPointer>
 #include <QMap>
 #include <QFile>
 
@@ -38,17 +39,16 @@ public slots:
     void addVPN(const QString &name, QProcess *proc);
 
 private:
-    QSignalMapper *logMapperStdout, *logMapperFinished;
-    QMap<QString, QProcess*> loggers;
+    QSignalMapper *logMapperFinished;
+    QMap<QString, QPointer<QProcess>> loggers;
     QMap<QString, QFile*> logfiles;
-    QMap<QString, bool> loglocker;
     QMap<QString, bool> logCertFailedMode;
     QMap<QString, QString> logCertFailedBuffer;
     QMap<QString, vpnProfile> vpnConfigs;
     tiConfMain main_settings;
 
 private slots:
-    void logVPNOutput(const QString &name);
+    void logVPNData(const QString &name, const QByteArray &data);
     void procFinished(const QString &name);
 
 signals:


### PR DESCRIPTION
Disclaimer: While I can read C/C++ to a certain extent, I've fully worked on fixing this issue with AI. I don't want, by any means, to pollute repositories with slop.

If I should make changes, I would love to have the opportunity to learn more from a review. Thank you for your patience! 🙏🏼

## Summary

- **Root cause**: `vpnLogger` runs in a dedicated `QThread` but was calling `QProcess::read()` on a `QProcess` owned by the main thread via a `QSignalMapper` queued connection. This caused `QRingBuffer` corruption and frequent segfaults, especially under heavy VPN I/O (large downloads).
- **Fix**: Read `QProcess` data in its owning thread using a `DirectConnection` lambda on `readyReadStandardOutput`, then queue the already-read `QByteArray` to the logger thread via `QMetaObject::invokeMethod` for processing.
- **Additional fixes in `vpnProcess`**:
  - Add null checks for `thread_worker` and `ptr_tunnel` in `onObserverUpdate()`, `updateStats()`, and `onStatsUpdate()` timer callbacks.
  - Stop observer timers before thread cleanup in `closeProcess()` to prevent use-after-free.
  - Initialize timer pointers to `nullptr` in the constructor.
- **Cleanup**: Remove unused `logMapperStdout`, dead `logVPNOutput` slot, unused `loglocker` map, and add proper cleanup of per-VPN maps in `procFinished()` to prevent resource leaks on reconnect.

## Crash backtrace (before fix)

```
#0  __memmove_avx_unaligned_erms (libc.so.6)
#1  QRingBuffer::read (libQt5Core.so.5)
#2  QIODevicePrivate::read (libQt5Core.so.5)
#3  QIODevice::read (libQt5Core.so.5)
#4  vpnLogger::logVPNOutput (openfortigui)
#5  vpnLogger::qt_static_metacall (openfortigui)
#6  QSignalMapper::mapped (libQt5Core.so.5)
```

## Test plan

- [x] Verified crash is reproducible before fix
- [x] Verified no crash after fix under sustained VPN usage with heavy downloads
- [x] Clean shutdown (exit code 0) confirmed
- [x] Compiles cleanly with CMake on Ubuntu 24.04 / Qt 5.15